### PR TITLE
Disable required on mappings configuration key

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,12 +23,11 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('mapping')
-                    ->isRequired()
-                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
                             ->scalarNode('entity')
+                                ->isRequired()
                             ->end()
                             ->arrayNode('map')
                                 ->useAttributeAsKey('name')
@@ -37,6 +36,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                    ->defaultValue(array())
                 ->end()
             ->end();
 


### PR DESCRIPTION
Hi,
It is not really mandatory but It was a little annoying to have to put the configuration at the start in the config.yml because I am going to use this bundle in a skeleton and configure it only later.
With this, you can enable the bundle and configure it later.
If you take this pull request, could you make a new stable release after please ?
Thanks in advance
Regards
